### PR TITLE
TFG-114 Solucionar fuga de dependencia en la implementación de los repsitorios

### DIFF
--- a/Backend/app/main.py
+++ b/Backend/app/main.py
@@ -10,7 +10,7 @@ from .dependencies.service_dependencies import (
     clear_service_dependency_caches,
     get_auth_service,
 )
-from .repositories.implementations.mongo.mongo_client import close_mongo_client
+from .repositories import close_database_connection
 from .routers.auth import auth_router
 from .routers.conversation import conversation_router
 from .routers.meeting import meeting_router
@@ -55,7 +55,7 @@ async def lifespan(app: FastAPI):
             with suppress(asyncio.CancelledError):
                 await task
         clear_service_dependency_caches()
-        close_mongo_client()
+        close_database_connection()
 
 
 app = FastAPI(title="TFG", openapi_tags=_tags_metadata, lifespan=lifespan)

--- a/Backend/app/repositories/__init__.py
+++ b/Backend/app/repositories/__init__.py
@@ -1,0 +1,5 @@
+from .implementations.mongo.mongo_client import close_mongo_client as _close
+
+
+def close_database_connection() -> None:
+    _close()


### PR DESCRIPTION
De este modo el cierre queda mejor centralizado, y el main no ve qué base de datos concreta se está utilizando